### PR TITLE
Adds query support and test

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,13 +29,31 @@ function detectYoutube (url) {
 }
 
 embed.vimeo = function (id, opts) {
-  // TODO: use opts to set query string, iframe attrs etc.
-  return '<iframe src="//player.vimeo.com/video/' + id + '" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>'
+  // TODO: use opts to set iframe attrs.
+  var queryString = ''
+  if (opts && opts.hasOwnProperty('query')){
+    queryString = "?" + serializeQuery(opts.query)
+  }
+  return '<iframe src="//player.vimeo.com/video/' + id + queryString + '" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>'
 }
 
 embed.youtube = function (id, opts) {
-  // TODO: use opts to set query string, iframe attrs etc.
-  return '<iframe src="//www.youtube.com/embed/' + id + '" frameborder="0" allowfullscreen></iframe>'
+  // TODO: use opts to set iframe attrs.
+  var queryString = ''
+  if (opts && opts.hasOwnProperty('query')){
+    queryString = "?" + serializeQuery(opts.query)
+  }
+  return '<iframe src="//www.youtube.com/embed/' + id + queryString + '" frameborder="0" allowfullscreen></iframe>'
+}
+
+function serializeQuery (query) {
+  var queryString = []
+  for(var p in query){
+    if (query.hasOwnProperty(p)) {
+      queryString.push(encodeURIComponent(p) + "=" + encodeURIComponent(query[p]));
+    }
+  }
+  return queryString.join("&")
 }
 
 module.exports = embed

--- a/test.js
+++ b/test.js
@@ -30,3 +30,15 @@ test("convert youtube id", function (t) {
   var code = embed.youtube("9XeNNqeHVDw")
   t.equal(code, '<iframe src="//www.youtube.com/embed/9XeNNqeHVDw" frameborder="0" allowfullscreen></iframe>')
 })
+
+test("accept query param youtube", function (t) {
+  t.plan(1)
+  var code = embed.youtube("9XeNNqeHVDw", { query: { rel: 0, showinfo: 0 } } )
+  t.equal(code, '<iframe src="//www.youtube.com/embed/9XeNNqeHVDw?rel=0&showinfo=0" frameborder="0" allowfullscreen></iframe>')
+})
+
+test("accept query param vimeo"), function (t) {
+  t.plan(1)
+  var code = embed.vimeo("19339941", { query: { portrait: 0, color: '333' } } )
+  t.equal(code, '<iframe src="//player.vimeo.com/video/19339941?portrait=0&color=333" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>')
+}


### PR DESCRIPTION
This would allow string params to be added to a video url.

To use it, the `opts` argument should contain an object called `query` in which each key and value will be converted to a query string and added to the URL.

(Sorry about my previous PR, I reverted too far and my attempts at fixing things only made it worse. Clean history :smile:  )