### PR TITLE
Extract video source from url

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ Returns an HTML `<img>` tag (string) for the given url and the `src` in a callba
 }
 ```
 
+### var embedCode = embed.videoSource(url)
+
+Returns an HTML `object` containing the video ID, video source (`"youtube"`, `"vimeo"`, `"dailymotion"`), and the original url. Works for **youtube**, **vimeo** and **dailymotion**.
+
+```js
+{
+  id: String,
+  url: String,
+  source: Enum "youtube", "vimeo", "dailymotion"
+}
+```
+
 ## Options
 
 ### query
@@ -163,6 +175,6 @@ embedVideo.image('https://www.dailymotion.com/video/x20qnej_red-bull-presents-wi
   console.log(thumbnail.src)
   // http://s1.dmcdn.net/IgPVQ/x720-d_h.jpg
   console.log(thumbnail.html)
-  // <img src="http://s1.dmcdn.net/IgPVQ/x720-d_h.jpg"/> 
+  // <img src="http://s1.dmcdn.net/IgPVQ/x720-d_h.jpg"/>
 })
 ```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
-var URL = require('url')
-var request = require('request')
+var URL = require('url');
+var request = require('request');
 var escape = require('lodash.escape');
+
+var YOUTUBE = 'youtube';
+var VIMEO = 'vimeo';
+var DAILYMOTION = 'dailymotion';
 
 var validVimeoOpts = [
   'thumbnail_small',
@@ -55,6 +59,39 @@ embed.image = function (url, opts, cb) {
   if (id) return embed.dailymotion.image(id, opts, cb)
 }
 
+embed.videoSource = function(url) {
+  var id
+
+  url = URL.parse(url, true)
+
+  id = detectYoutube(url)
+  if (id) {
+    return {
+      id: id,
+      source: YOUTUBE,
+      url: url.href
+    }
+  }
+
+  id = detectVimeo(url)
+  if (id) {
+    return {
+      id: id,
+      source: VIMEO,
+      url: url.href
+    }
+  }
+
+  id = detectDailymotion(url)
+  if (id) {
+    return {
+      id: id,
+      source: DAILYMOTION,
+      url: url.href
+    }
+  }
+}
+
 function detectVimeo (url) {
   return (url.hostname == "vimeo.com") ? url.pathname.split("/")[1] : null
 }
@@ -90,7 +127,7 @@ embed.vimeo = function (id, opts) {
     queryString = "?" + serializeQuery(opts.query)
   }
 
-  return '<iframe src="//player.vimeo.com/video/' 
+  return '<iframe src="//player.vimeo.com/video/'
           + id + opts.query + '"' + opts.attr
           + ' frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>'
 }
@@ -98,7 +135,7 @@ embed.vimeo = function (id, opts) {
 embed.youtube = function (id, opts) {
   opts = parseOptions(opts);
 
-  return '<iframe src="//www.youtube.com/embed/' 
+  return '<iframe src="//www.youtube.com/embed/'
           + id + opts.query + '"' + opts.attr
           + ' frameborder="0" allowfullscreen></iframe>'
 }

--- a/test.js
+++ b/test.js
@@ -141,3 +141,53 @@ test("get dailymotion thumbnail (dai.ly)", function(t) {
     t.equal(thumbnail.html, '<img src="http://s1.dmcdn.net/IgPVQ/x480-ktj.jpg"/>', 'and an html tag')
   })
 })
+
+test("get vimeo source", function (t) {
+  t.plan(3)
+  var url = "http://vimeo.com/19339941"
+  var code = embed.videoSource(url)
+
+  t.equal(code.id, '19339941')
+  t.equal(code.source, 'vimeo')
+  t.equal(code.url, url)
+})
+
+test("get youtube.com source", function (t) {
+  t.plan(3)
+  var url = "https://www.youtube.com/watch?v=twE64AuqE9A"
+  var code = embed.videoSource(url)
+
+  t.equal(code.id, 'twE64AuqE9A')
+  t.equal(code.source, 'youtube')
+  t.equal(code.url, url)
+})
+
+test("get youtu.be source", function (t) {
+  t.plan(3)
+  var url = "http://youtu.be/9XeNNqeHVDw#aid=P-Do3JLm4A0"
+  var code = embed.videoSource(url)
+
+  t.equal(code.id, '9XeNNqeHVDw')
+  t.equal(code.source, 'youtube')
+  t.equal(code.url, url)
+})
+
+test("get dailymotion.co, source", function (t) {
+  t.plan(3)
+  var url = "https://www.dailymotion.com/video/x20qnej_red-bull-presents-wild-ride-bmx-mtb-dirt_sport"
+  var code = embed.videoSource(url)
+
+  t.equal(code.id, 'x20qnej')
+  t.equal(code.source, 'dailymotion')
+  t.equal(code.url, url)
+})
+
+test("get dai.ly source", function (t) {
+  t.plan(3)
+  var url = "http://dai.ly/x20qnej"
+  var code = embed.videoSource(url)
+
+  t.equal(code.id, 'x20qnej')
+  t.equal(code.source, 'dailymotion')
+  t.equal(code.url, url)
+})


### PR DESCRIPTION
It would be beneficial to be able to extract the source (id and channel) of a video URL so it can be saved into a database. This will provide more structure and be more understandable when constructing an embed iframe at a later time.