### PR TITLE
Declare queryString

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ var YOUTUBE = 'youtube';
 var VIMEO = 'vimeo';
 var DAILYMOTION = 'dailymotion';
 
+var queryString;
+
 var validVimeoOpts = [
   'thumbnail_small',
   'thumbnail_medium',


### PR DESCRIPTION
Some module bundlers that insert use-strict would result in an exception when an undeclared queryString was accessed.