### PR TITLE
Resolve Issue #16: Match Vimeo channel and group URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,8 @@ var validDailyMotionOpts = [
   'thumbnail_1080_url'
 ];
 
+var VIMEO_MATCH_RE = /^(?:\/video|\/channels\/[\w-]+|\/groups\/[\w-]+\/videos)?\/(\d+)$/;
+
 function embed (url, opts) {
   var id
 
@@ -94,7 +96,8 @@ embed.videoSource = function(url) {
 }
 
 function detectVimeo (url) {
-  return (url.hostname == "vimeo.com") ? url.pathname.split("/")[1] : null
+  var match;
+  return (url.hostname === "vimeo.com" && (match = VIMEO_MATCH_RE.exec(url.pathname))) ?  match[1] : null;
 }
 
 function detectYoutube (url) {

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ var validDailyMotionOpts = [
   'thumbnail_1080_url'
 ];
 
-var VIMEO_MATCH_RE = /^(?:\/video|\/channels\/[\w-]+|\/groups\/[\w-]+\/videos)?\/(\d+)$/;
+var VIMEO_MATCH_RE = /^(?:\/video|\/channels\/[\w-]+|\/groups\/[\w-]+\/videos)?\/(\d+)/;
 
 function embed (url, opts) {
   var id

--- a/test.js
+++ b/test.js
@@ -152,6 +152,26 @@ test("get vimeo source", function (t) {
   t.equal(code.url, url)
 })
 
+test("get vimeo source from channel", function(t) {
+  t.plan(3)
+  var url = "https://vimeo.com/channels/staffpicks/185045662"
+  var code = embed.videoSource(url);
+  
+  t.equal(code.id, "185045662")
+  t.equal(code.source, "vimeo")
+  t.equal(code.url, url)
+});
+
+test("get vimeo source from group", function(t) {
+  t.plan(3)
+  var url = "https://vimeo.com/groups/1minute/videos/261712339"
+  var code = embed.videoSource(url);
+  
+  t.equal(code.id, "261712339")
+  t.equal(code.source, "vimeo")
+  t.equal(code.url, url)
+});
+
 test("get youtube.com source", function (t) {
   t.plan(3)
   var url = "https://www.youtube.com/watch?v=twE64AuqE9A"

--- a/test.js
+++ b/test.js
@@ -172,6 +172,16 @@ test("get vimeo source from group", function(t) {
   t.equal(code.url, url)
 });
 
+test("get vimeo source with trailing slash", function(t) {
+  t.plan(3)
+  var url = "https://vimeo.com/groups/1minute/videos/261712339/"
+  var code = embed.videoSource(url);
+  
+  t.equal(code.id, "261712339")
+  t.equal(code.source, "vimeo")
+  t.equal(code.url, url)
+});
+
 test("get youtube.com source", function (t) {
   t.plan(3)
   var url = "https://www.youtube.com/watch?v=twE64AuqE9A"


### PR DESCRIPTION
This PR resolves issue #16 by switching Vimeo detection that matches videos while allowing for channel and group memberships to be present in the URL. Examples of URLs that were failing to embed correctly are present in 8601a28. 

I experimented with a multiline detectVimeo function but have left it as a single line operation since it fits within my editor's line length preferences :-)