### PR TITLE
Prevent mixed content warning by using SSL when connecting to vimeo.com

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ embed.vimeo.image = function (id, opts, cb) {
 
   opts.image = validVimeoOpts.indexOf(opts.image) >= 0 ? opts.image : 'thumbnail_large'
 
-  fetch('http://vimeo.com/api/v2/video/' + id + '.json')
+  fetch('https://vimeo.com/api/v2/video/' + id + '.json')
     .then(function (res) {
       if (res.status !== 200) {
         throw new Error('unexpected response from vimeo')


### PR DESCRIPTION
When requesting a Vimeo thumbnail URL from a secure origin, Chrome displays the following error:

> Mixed Content: The page at '{{URL}}' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://vimeo.com/api/v2/video/35159390.json'. This request has been blocked; the content must be served over HTTPS.

I have tested Vimeo.com with SSLLabs, and verified that it receives an A+ score, indicating that a wide range of browsers and platforms are supported.