### PR TITLE
fix: return undefined if `hostname` is not present

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,10 @@ embed.info = function (url) {
   url = URL.parse(url, true)
 
   var id
+  
+  if (!url.hostname) {
+    return undefined
+  }
 
   id = detectYoutube(url)
   if (id) {


### PR DESCRIPTION
This prevents an error when passing URLs without a protocol i.e. `www.mysite.com`, which don't have a `hostname` (among other things)